### PR TITLE
Make symlinks relative

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "grunt-via-filesystem",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Grunt plugin for setting up a project filesystem at Via Studio.",
     "repository": "git@github.com:viastudio/grunt-via-filesystem.git",
     "author": {

--- a/tasks/via_filesystem.js
+++ b/tasks/via_filesystem.js
@@ -19,18 +19,14 @@ module.exports = function(grunt) {
      * @returns {null}
      */
     function createSymbolicLink(srcPath, destPath) {
-
-        var srcAbsolutePath = path.resolve(process.cwd(), srcPath);
-        var destAbsolutePath = path.resolve(process.cwd(), destPath);
-
-        if (!grunt.file.exists(srcAbsolutePath) && !grunt.file.isLink(srcAbsolutePath)) {
+        if (!grunt.file.exists(srcPath) && !grunt.file.isLink(srcPath)) {
             grunt.log.error().error('Symbolic link source directory does not exist: ' + srcPath.red);
             return;
         }
 
         if (!grunt.file.exists(destPath)) {
             grunt.log.write(destPath.cyan + ' -> ' + srcPath.cyan + '... ');
-            fs.symlinkSync(srcAbsolutePath, destAbsolutePath);
+            fs.symlinkSync(srcPath, destPath);
             grunt.log.ok();
         } else {
             grunt.log.writeln('Destination path already exists: ' + destPath.cyan);


### PR DESCRIPTION
This makes symlinks use relative instead of absolute paths. (Symlinks in your Gruntfile that have an absolute path will still use the absolute path)

For example `wp-config.php` will now symlink to `wp-via-config.php` instead of `/full/path/to/wp-via-config.php`