### PR TITLE
chore: use github dependency instead of ssh

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "license": "MIT",
     "dependencies": {
-        "via-environment": "git+ssh://git@github.com/viastudio/npm-via-environment.git"
+        "via-environment": "viastudio/npm-via-environment"
     },
     "devDependencies": {
         "grunt-contrib-clean": "~0.5.0",


### PR DESCRIPTION
The SSH dependency doesn't work for all git setups.
